### PR TITLE
Add SECURE_VERSION_NUM attribute

### DIFF
--- a/data/p10/attribute_types_obmc.xml
+++ b/data/p10/attribute_types_obmc.xml
@@ -697,4 +697,18 @@
         </simpleType>
     </attribute>
 
+    <attribute>
+        <description>The number of secure version currently installed on the system.
+                     Hostboot passes this number to the BMC
+        </description>
+        <id>SECURE_VERSION_NUM</id>
+        <persistency>non-volatile</persistency>
+        <readable></readable>
+        <simpleType>
+            <uint8_t>
+                <default>0</default>
+            </uint8_t>
+        </simpleType>
+    </attribute>
+
 </attributes>

--- a/data/p10/filter_AttributesList.lsv
+++ b/data/p10/filter_AttributesList.lsv
@@ -117,3 +117,4 @@ CA:AFFINITY_PATH
 # CHIP_UNIT attribute require to fill index and CHIP_UNIT_POS
 # attribute value but not require in device tree
 CA:CHIP_UNIT
+CA:SECURE_VERSION_NUM

--- a/data/p10/target_types_obmc.xml
+++ b/data/p10/target_types_obmc.xml
@@ -38,6 +38,9 @@
         <attribute>
             <id>DISABLE_SECURITY</id>
         </attribute>
+        <attribute>
+            <id>SECURE_VERSION_NUM</id>
+        </attribute>
         <id>sys-sys-power10</id>
         <parent>sys</parent>
     </targetType>


### PR DESCRIPTION
This commit adds a new attribute to DEVTREE called SECURE_VERSION_NUM.
This attribute indicates the level of secure version installed on the
system. Hostboot will update this attribute during IPL.