### PR TITLE
data: p10: Change SECURE_VERSION_NUM attribute to SECURE_VERSION_SEEPROM

### DIFF
--- a/data/p10/attribute_types_obmc.xml
+++ b/data/p10/attribute_types_obmc.xml
@@ -701,7 +701,7 @@
         <description>The number of secure version currently installed on the system.
                      Hostboot passes this number to the BMC
         </description>
-        <id>SECURE_VERSION_NUM</id>
+        <id>SECURE_VERSION_SEEPROM</id>
         <persistency>non-volatile</persistency>
         <readable></readable>
         <simpleType>

--- a/data/p10/filter_AttributesList.lsv
+++ b/data/p10/filter_AttributesList.lsv
@@ -117,4 +117,4 @@ CA:AFFINITY_PATH
 # CHIP_UNIT attribute require to fill index and CHIP_UNIT_POS
 # attribute value but not require in device tree
 CA:CHIP_UNIT
-CA:SECURE_VERSION_NUM
+CA:SECURE_VERSION_SEEPROM

--- a/data/p10/target_types_obmc.xml
+++ b/data/p10/target_types_obmc.xml
@@ -39,7 +39,7 @@
             <id>DISABLE_SECURITY</id>
         </attribute>
         <attribute>
-            <id>SECURE_VERSION_NUM</id>
+            <id>SECURE_VERSION_SEEPROM</id>
         </attribute>
         <id>sys-sys-power10</id>
         <parent>sys</parent>


### PR DESCRIPTION
SECURE_VERSION_NUM attribute name that we sync to BMC to indicate the
number of secure version currently installed on the system needs to be
changed to SECURE_VERSION_SEEPROM (this is the existing HB attribute
for this purpose).

Signed-off-by: Ilya Smirnov <ismirno@us.ibm.com>