### PR TITLE
data: p10:  Add 'functionalOverride' bit to HWAS_STATE

### DIFF
--- a/data/p10/attribute_types_obmc.xml
+++ b/data/p10/attribute_types_obmc.xml
@@ -53,7 +53,7 @@
     <attribute>
         <complexType>
             <description>
-                Structure consisting of an EID (or reason), 5 booleans, and 3 reserved
+                Structure consisting of an EID (or reason), 6 booleans, and 2 reserved
                 bits
             </description>
             <field>
@@ -117,7 +117,23 @@
                 <type>uint8_t</type>
             </field>
             <field>
-                <bits>3</bits>
+                <bits>1</bits>
+                <default>0</default>
+                <description> If a core was deconfigured due to
+                    Field Core Override (FCO) set this bit.
+                    This is used by HB and BMC during reconfig
+                    loops to treat cores deconfigured by FCO as
+                    functional.
+                    0b0: leave target functional bit unchanged
+                         during reconfig loops.
+                    0b1: set target functional bit to 1 during
+                         reconfig loops.
+                </description>
+                <name>functionalOverride</name>
+                <type>uint8_t</type>
+            </field>
+            <field>
+                <bits>2</bits>
                 <default>0</default>
                 <description>Reserved for future use</description>
                 <name>reserved</name>


### PR DESCRIPTION
Currently, when Field Core Override is set on BMC, HB
will restrict the number of cores to run by setting
their HWAS_STATE functional to 0 (ie not functional).
This creates a problem when FCO is set to a low number
of cores and then a Graceful reconfig loop is triggered.
BMC preserves HB's HWAS_STATE during Graceful reboots
and hands it off to SBE. This leads to undesirable
behavior since the cores knocked out by FCO will not be
considered by SBE to boot with even though they are
still technically functional.

To remedy this, HB will add anther bit in HWAS_STATE,
functionalOverride, which will be set for cores with
deconfigured by FCO in addition to setting HWAS_STATE
functional = 0.
ie:
    core0HwasState.deconfiguredByEid
                   = DECONFIGURED_BY_FIELD_CORE_OVERRIDE
    core0HwasState.functional = 0
    core0HwasState.functionalOverride = 1

BMC will key off of functionalOverride to reset target's
HWAS_STATE functional = 1. This is will make FCO cores
available for SBE to boot with. HB will do the same in
istep 6 to stay in sync with SBE.

This commit adds the new 'functionalOverride' bit to
HWAS_STATE

Signed-off-by: Jayanth Othayoth <ojayanth@in.ibm.com>