### PR TITLE
scripts: genDTS: Fix, index property for PMIC and Generic_I2C_Devices

### DIFF
--- a/scripts/genDTS.pl
+++ b/scripts/genDTS.pl
@@ -487,12 +487,18 @@ sub processTargetPath
         my $nodeName = $lastNode->nodeName;
         $nodeName =~ s/generic_i2c_device/adc/g;
         $lastNode->nodeName($nodeName);
+        $lastNode->index(${$lastNode->attributeList}{"FAPI_POS"}->value);
     }
     elsif ($lastNode->compatible eq "chip-PCA9554")
     {
         my $nodeName = $lastNode->nodeName;
         $nodeName =~ s/generic_i2c_device/gpio_expander/g;
         $lastNode->nodeName($nodeName);
+        $lastNode->index(${$lastNode->attributeList}{"FAPI_POS"}->value);
+    }
+    elsif ($lastNode->compatible eq "chip-vreg-generic")
+    {
+        $lastNode->index(${$lastNode->attributeList}{"FAPI_POS"}->value);
     }
 
     # Add the reg property for the target if that contains "I2C_ADDRESS"


### PR DESCRIPTION
- Currently, the index property is filled by using the parent omi
  target CHIP_UNIT attributes like dimm, ocmb, and mem_port for the pmic
  and generic i2c device targets but these targets are sitting under
  the ocmb and more one pmic or generic i2c device targets is possible
  not like one dimm, ocmb, and mem_port per omi so, the index property
  value are repeating and we may not get the attributes of the
  corresponding target via cronus target name that uses the index
  property value.

- So, fixing the index property value by using the FAPI_POS attribute
  of the pmic and generic i2c device targets and that attribute value is
  unique within the system.

Tested:

- Without fix:

```
> attributes export | grep target | grep pmic | grep p00

target = p10.pmic:k0:n0:s0:p00:c0
target = p10.pmic:k0:n0:s0:p00:c1
target = p10.pmic:k0:n0:s0:p00:c2
target = p10.pmic:k0:n0:s0:p00:c3
target = p10.pmic:k0:n0:s0:p00:c0
target = p10.pmic:k0:n0:s0:p00:c1
target = p10.pmic:k0:n0:s0:p00:c2
target = p10.pmic:k0:n0:s0:p00:c3
...

```

- With fix

```
> attributes export | grep target | grep pmic | grep p00

target = p10.pmic:k0:n0:s0:p00:c0
target = p10.pmic:k0:n0:s0:p00:c1
target = p10.pmic:k0:n0:s0:p00:c2
target = p10.pmic:k0:n0:s0:p00:c3
target = p10.pmic:k0:n0:s0:p00:c4
target = p10.pmic:k0:n0:s0:p00:c5
target = p10.pmic:k0:n0:s0:p00:c6
target = p10.pmic:k0:n0:s0:p00:c7
...

```