### PR TITLE
data/p10: ATTR_SYS_CLOCK_DECONFIG_STATE size update

### DIFF
--- a/data/p10/attribute_types_obmc.xml
+++ b/data/p10/attribute_types_obmc.xml
@@ -791,7 +791,7 @@
                 <default>NO_DECONFIG</default>
                 <id>SYS_CLOCK_DECONFIG_STATE</id>
             </enumeration>
-            <uint8_t></uint8_t>
+            <uint32_t></uint32_t>
         </simpleType>
     </attribute>
 


### PR DESCRIPTION
ATTR_SYS_CLOCK_DECONFIG_STATE attribute hostboot is defined
as 4 byte size enum. Chnaging size enum size 1 -> 4 byte.

