### PR TITLE
scripts : Port MRW parser changes from hostboot

### DIFF
--- a/scripts/Targets.pm
+++ b/scripts/Targets.pm
@@ -834,6 +834,17 @@ sub getTargetPosition
 }
 
 
+#--------------------------------------------------
+# @brief Generate the fapi string for a given target
+#
+# @param[in] $self   - The global target object
+# @param[in] $targetType - The target type to get name of
+# @param[in] $node - The node parent of the input target
+# @param[in] $chipPos - chip position relative to node
+# @param[in] $chipletPos - unit position relative to chip
+#
+# @return the position of the target given
+#--------------------------------------------------
 sub getFapiName
 {
     my $self        = shift;
@@ -1957,13 +1968,6 @@ sub setMruid
 
     my $type          = $self->getType($target);
     my $mru_prefix_id = $self->{enumeration}->{MRU_PREFIX}->{$type};
-
-    # TODO RTC 291151 - remove when FC is added to MRU_PREFIX type
-    # Do this substitution while FC is not an MRU_PREFIX type
-    if ((!defined $mru_prefix_id) && ($type eq "FC"))
-    {
-        $mru_prefix_id = $self->{enumeration}->{MRU_PREFIX}->{"EX"};
-    }
 
     if ( (!defined $mru_prefix_id) ||
          ($mru_prefix_id eq "")    ||


### PR DESCRIPTION
scripts : Port MRW parser changes from hostboot

Hostboot made changes to the MRW parser scripts to support new system type the same has been ported over to BMC for device tree generation.

- processMrw.pl
  hostboot/src/usr/targeting/common/processMrw.pl

- Targets.pm
  hostboot/src/usr/targeting/common/Targets.pm

- BusFruCallouts.pm
  hostboot/src/usr/targeting/common/BusFruCallouts.pm

Tested:
1) Everest used Everest-MRW.dtb device tree file and
ensured system reached runtime.

2) Raininer2U used Rainier-2U-MRW.dtb device tree
file and ensured system reached runtime.

3) Rainier4U used Rainier-4U-MRW.dtb device tree file and
ensured system reached runtime.

Change-Id: I853f53fcec35c499a39295dd34037f08c9867a95
Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>