### PR TITLE
Changes to support new DIMM and OCMB types for Bonnell

### DIFF
--- a/data/p10/FAPITargetsNameMapList.lsv
+++ b/data/p10/FAPITargetsNameMapList.lsv
@@ -21,9 +21,9 @@ TARGET_TYPE_MI:unit-mi-power10
 TARGET_TYPE_MCC:unit-mcc-power10
 TARGET_TYPE_OMIC:unit-omic-power10
 TARGET_TYPE_OMI:unit-omi-power10
-TARGET_TYPE_OCMB_CHIP:chip-ocmb
+TARGET_TYPE_OCMB_CHIP:chip-ocmb,chip-ocmb-planar
 TARGET_TYPE_MEM_PORT:unit-mem_port
-TARGET_TYPE_DIMM:lcard-dimm-ddimm,lcard-dimm-ddimm4u
+TARGET_TYPE_DIMM:lcard-dimm-ddimm,lcard-dimm-ddimm4u,lcard-dimm-ddr4
 TARGET_TYPE_ABUS:unit-abus-power10
 # Generic I2C Devices (aka ADC and GPIO Expanders)
 TARGET_TYPE_GENERICI2CSLAVE:chip-adc,chip-PCA9554

--- a/data/p10/filter_TargetsList.lsv
+++ b/data/p10/filter_TargetsList.lsv
@@ -17,9 +17,11 @@ unit-mcc-power10
 unit-omic-power10
 unit-omi-power10
 chip-ocmb
+chip-ocmb-planar
 unit-mem_port
 lcard-dimm-ddimm
 lcard-dimm-ddimm4u
+lcard-dimm-ddr4
 # In MRW smpgroup target type used as "unit-abus-power10" and instance name will
 # contain "group" to differentiate between abus and smpgroup if system
 # supporting smpgroup target so, using "unit-abus-power10" to get smpgroup.

--- a/data/p10/pdbg_compatible_propMapping.lsv
+++ b/data/p10/pdbg_compatible_propMapping.lsv
@@ -19,9 +19,11 @@ unit-mcc-power10:ibm,power10-mcc
 unit-omic-power10:ibm,power10-omic
 unit-omi-power10:ibm,power10-omi
 chip-ocmb:"ibm,power-ocmb", "ibm,power10-ocmb"
+chip-ocmb-planar:"ibm,power-ocmb", "ibm,power10-ocmb"
 unit-mem_port:ibm,power10-memport
 lcard-dimm-ddimm:ibm,power10-dimm
 lcard-dimm-ddimm4u:ibm,power10-dimm
+lcard-dimm-ddr4:ibm,power10-dimm
 # Using smpgroup instead abus in compatible property as per
 # PHYS_PATH attribute which is changed in processMrw.pl
 unit-abus-power10:ibm,power10-smpgroup

--- a/data/p10/target_types_obmc.xml
+++ b/data/p10/target_types_obmc.xml
@@ -188,6 +188,10 @@
         <parent>chip</parent>
     </targetType>
     <targetType>
+        <id>chip-ocmb-planar</id>
+        <parent>chip</parent>
+    </targetType>
+    <targetType>
         <id>unit-mem_port</id>
         <parent>unit</parent>
     </targetType>
@@ -197,6 +201,10 @@
     </targetType>
     <targetType>
         <id>lcard-dimm-ddimm4u</id>
+        <parent>lcard-dimm</parent>
+    </targetType>
+    <targetType>
+        <id>lcard-dimm-ddr4</id>
         <parent>lcard-dimm</parent>
     </targetType>
     <targetType>


### PR DESCRIPTION
Change-Id: Ica92c337c2e23c618cec205595c0bb0e9b695aed