### PR TITLE
dt-api : do not log error trace if attribute not found in the target

### DIFF
--- a/libdt-api/dt_api.C
+++ b/libdt-api/dt_api.C
@@ -30,7 +30,6 @@ namespace fapi2
         {
             if (!pdbg_target_get_attribute_packed(target, attrIdWONS.c_str(), attrSpec.c_str(), eleCount, val))
             {
-                std::cerr << "pdbg_target_get_attribute_packed failed" << std::endl;
                 return 1; // FAPI2_RC_INVALID_ATTR_GET
             }
         }
@@ -51,7 +50,6 @@ namespace fapi2
         {
             if (!pdbg_target_get_attribute(target, attrIdWONS.c_str(), std::stoi(attrSpec), eleCount, val))
             {
-                std::cerr << "pdbg_target_get_attribute failed" << std::endl;
                 return 1; // FAPI2_RC_INVALID_ATTR_GET
             }
         }


### PR DESCRIPTION
while trying to read ATTR_HWAS_STATE property for all the targets present in the system noticed the journal is flooded with "pdbg_target_get_attribute_packed failed" traces as some of the targets do not have ATTR_HWAS_STATE property

At present, the getProperty method is returning
FAPI2_RC_INVALID_ATTR_GET error with which the caller can choose to log an error or ignore the target.


Change-Id: I00f4cdd397388aa8a4a9a4c15235279da8686929