### PR TITLE
Fix proc perv chipunit alignment

### DIFF
--- a/data/p10/FAPITargetsNameMapList.lsv
+++ b/data/p10/FAPITargetsNameMapList.lsv
@@ -23,7 +23,6 @@ TARGET_TYPE_OMIC:unit-omic-power10
 TARGET_TYPE_OMI:unit-omi-power10
 TARGET_TYPE_OCMB_CHIP:chip-ocmb,chip-ocmb-planar
 TARGET_TYPE_MEM_PORT:unit-mem_port
-TARGET_TYPE_PERV:unit-perv
 TARGET_TYPE_DIMM:lcard-dimm-ddimm,lcard-dimm-ddimm4u,lcard-dimm-ddr4,unit-ddr,unit-ddr4-jedec,unit-ddr5-jedec
 TARGET_TYPE_ABUS:unit-abus-power10
 # Generic I2C Devices (aka ADC and GPIO Expanders)

--- a/data/p10/pdbg_compatible_propMapping.lsv
+++ b/data/p10/pdbg_compatible_propMapping.lsv
@@ -21,7 +21,7 @@ unit-omi-power10:ibm,power10-omi
 chip-ocmb:"ibm,power-ocmb", "ibm,power10-ocmb"
 chip-ocmb-planar:"ibm,power-ocmb", "ibm,power10-ocmb"
 unit-mem_port:ibm,power10-memport
-unit-perv:ibm,power10-chiplet
+unit-perv:ibm,ody-chiplet
 lcard-dimm-ddimm:ibm,power10-dimm
 lcard-dimm-ddimm4u:ibm,power10-dimm
 lcard-dimm-ddr4:ibm,power10-dimm

--- a/data/p10/target_types_obmc.xml
+++ b/data/p10/target_types_obmc.xml
@@ -109,7 +109,7 @@
     </targetType>
     <targetType>
         <id>unit-perv-power10</id>
-        <parent>unit-perv</parent>
+        <parent>unit</parent>
     </targetType>
     <targetType>
         <id>unit-perv</id>
@@ -195,10 +195,6 @@
         <id>unit-mem_port</id>
         <parent>unit</parent>
     </targetType>
-    <targetType>
-        <id>unit-perv</id>
-        <parent>unit</parent>
-    </targetType>    
     <targetType>
         <id>lcard-dimm-ddimm</id>
         <parent>lcard-dimm</parent>

--- a/libdtree/dtree_util.c
+++ b/libdtree/dtree_util.c
@@ -61,6 +61,7 @@ struct {
 	{ "TARGET_TYPE_PEC", "pec", "pec" },
 	{ "TARGET_TYPE_PERV", "chiplet", "perv" },
 	{ "TARGET_TYPE_PERV", "perv", "perv" },
+	{ "TARGET_TYPE_PERV", "ody_chiplet", "perv" },
 	{ "TARGET_TYPE_PHB", "phb", "phb" },
 	{ "TARGET_TYPE_PMIC", "pmic", "pmic" },
 	{ "TARGET_TYPE_PPE", "ppe", "ppe" },

--- a/scripts/genDTS.pl
+++ b/scripts/genDTS.pl
@@ -541,6 +541,11 @@ sub processTargetPath
     {
         $lastNode->index(${$lastNode->attributeList}{"FAPI_POS"}->value);
     }
+    elsif ( (index ($lastNode->compatible, "unit-ddr") != -1) or
+          (index ($lastNode->compatible, "unit-mem_port") != -1) )
+    {
+        $lastNode->index(${$lastNode->attributeList}{"FAPI_POS"}->value);
+    }
 
     # Add the reg property for the target if that contains "I2C_ADDRESS"
     # attribute to perform the i2c read and write operation on this target.

--- a/scripts/genDTS.pl
+++ b/scripts/genDTS.pl
@@ -219,7 +219,7 @@ sub prepareDeviceTreeHierarchy
              index( $mrwTargetList{$MRWTargetID}->targetType, "ddr") != -1 or
              index( $mrwTargetList{$MRWTargetID}->targetType, "chip-ocmb") != -1 or
              index( $mrwTargetList{$MRWTargetID}->targetType, "unit-mem_port") != -1 or
-             index( $mrwTargetList{$MRWTargetID}->targetType, "unit-perv") != -1 or
+             $mrwTargetList{$MRWTargetID}->targetType eq "unit-perv" or
              index( $mrwTargetList{$MRWTargetID}->targetType, "chip-vreg-generic") != -1 or
              index( $mrwTargetList{$MRWTargetID}->targetType, "chip-adc") != -1 or
              index( $mrwTargetList{$MRWTargetID}->targetType, "chip-PCA9554") != -1
@@ -491,8 +491,7 @@ sub processTargetPath
     {
         $lastNode->index(${$lastNode->attributeList}{"CHIP_UNIT"}->value);
     }
-
-    # Filling index for ocmb, memport, dimm targets based on omi target
+    # Filling index for ocmb based on omi target
     # CHIP_UNIT attribute because, those targets are not pervasive target
     if ( index( $lastNode->compatible, "chip-ocmb") != -1 )
     {
@@ -509,12 +508,10 @@ sub processTargetPath
 
         # Changing node name for ocmb target as per pdbg expectation.
         # Removing "_chip" from ocmb target element value from PHYS_PATH value.
-        if (index( $lastNode->compatible, "chip-ocmb") != -1)
-        {
-            my $nodeName = $lastNode->nodeName;
-            $nodeName =~ s/_chip//g;
-            $lastNode->nodeName($nodeName);
-        }
+        my $nodeName = $lastNode->nodeName;
+        $nodeName =~ s/_chip//g;
+        $lastNode->nodeName($nodeName);
+
     }
     elsif ($lastNode->compatible eq "unit-fsi")
     {


### PR DESCRIPTION
The pervasive chipunits under the proc got misaligned because the mrw name of that is a substring of odyssey perv chip unit's and so the condition got satisfied.

Make the condition stricter to match the complete string. With this the issue is resolved.