### PR TITLE
Fix dimm index numbers in bonnell

### DIFF
--- a/scripts/genDTS.pl
+++ b/scripts/genDTS.pl
@@ -541,8 +541,9 @@ sub processTargetPath
     {
         $lastNode->index(${$lastNode->attributeList}{"FAPI_POS"}->value);
     }
-    elsif ( (index ($lastNode->compatible, "unit-ddr") != -1) or
-          (index ($lastNode->compatible, "unit-mem_port") != -1) )
+    elsif ( (index ($lastNode->compatible, "ddr") != -1) or
+          (index ($lastNode->compatible, "unit-mem_port") != -1) or 
+          ($lastNode->compatible eq "unit-perv") )
     {
         $lastNode->index(${$lastNode->attributeList}{"FAPI_POS"}->value);
     }


### PR DESCRIPTION
Regardless of the DIMM type, whether it be DDR4 or DDR5, the index value assigned to the DIMMs must correspond to the FAPI_POS.

Also for the Perv targets, the index numbers are the same. So use FAPI_POS as the index value.

Test results:
Tested and works as expected.